### PR TITLE
fix: race condition with external binaries and files with the same content

### DIFF
--- a/lib/phoenix_bakery.ex
+++ b/lib/phoenix_bakery.ex
@@ -25,9 +25,8 @@ defmodule PhoenixBakery do
   @doc false
   def run(type, content, cmd, opts) do
     dir = Path.join([System.tmp_dir!(), "phoenix_bakery", to_string(type)])
-    hash = Base.url_encode64(:erlang.md5(content), padding: false)
     File.mkdir_p!(dir)
-    file = Path.join(dir, hash)
+    file = Path.join(dir, to_string(System.unique_integer()))
     File.write!(file, content)
 
     try do


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix/pull/5246 causes Phoenix to run asset compression in parallel. If some of the files have the same contents, creating a filename based on the md5 of the content is not unique anymore. This results in multiple processes working on the same file at once.

The issue is easily noticable, since `File.rm` complains if the file doesn't exist. This is not an artifical example, since auto generated OpenStreetMap vector tiles are often empty and thus also have the same contents.